### PR TITLE
[WIP] Migate to esm

### DIFF
--- a/.mocha/framework.json
+++ b/.mocha/framework.json
@@ -1,6 +1,9 @@
 {
-    "spec": "dist/tests/framework/**/*.test.js",
-    "require": "dist/tests/helpers/mocha/frameworkMochaWrapper.js",
+    "spec": "tests/framework/**/*.test.js",
+    "require": [
+        "tsx",
+        "tests/helpers/mocha/frameworkMochaWrapper.ts"
+    ],
     "exit": true,
     "timeout": 5000,
     "parallel": true,

--- a/.mocha/routes.json
+++ b/.mocha/routes.json
@@ -1,6 +1,9 @@
 {
-    "spec": "dist/tests/routes/**/*.test.js",
-    "require": "dist/tests/helpers/mocha/routesMochaWrapper.js",
+    "spec": "tests/routes/**/*.test.ts",
+    "require": [
+        "tsx",
+        "tests/helpers/mocha/routesMochaWrapper.ts"
+    ],
     "exit": true,
     "timeout": 5000,
     "parallel": true,

--- a/index.ts
+++ b/index.ts
@@ -1,7 +1,7 @@
-import { initApp } from './src/app';
-import { initDb } from './src/services/env-helpers/db';
-import { initLocalStackS3 } from './src/services/env-helpers/s3';
-import { slog } from './src/services/logging';
+import { initApp } from './src/app.js';
+import { initDb } from './src/services/env-helpers/db.js';
+import { initLocalStackS3 } from './src/services/env-helpers/s3.js';
+import { slog } from './src/services/logging/index.js';
 
 const start = async () => {
     await initLocalStackS3();

--- a/package-lock.json
+++ b/package-lock.json
@@ -50,6 +50,7 @@
                 "prettier": "^3.1.0",
                 "sinon": "^17.0.2",
                 "supertest": "^7.0.0",
+                "tsx": "^4.10.0",
                 "typescript": "^5.2.2"
             },
             "engines": {
@@ -997,6 +998,374 @@
             },
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/@esbuild/aix-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.20.2.tgz",
+            "integrity": "sha512-D+EBOJHXdNZcLJRBkhENNG8Wji2kgc9AZ9KiPr1JuZjsNtyHzrsfLRrY0tk2H2aoFu6RANO1y1iPPUCDYWkb5g==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "aix"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.20.2.tgz",
+            "integrity": "sha512-t98Ra6pw2VaDhqNWO2Oph2LXbz/EJcnLmKLGBJwEwXX/JAN83Fym1rU8l0JUWK6HkIbWONCSSatf4sf2NBRx/w==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.20.2.tgz",
+            "integrity": "sha512-mRzjLacRtl/tWU0SvD8lUEwb61yP9cqQo6noDZP/O8VkwafSYwZ4yWy24kan8jE/IMERpYncRt2dw438LP3Xmg==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/android-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.20.2.tgz",
+            "integrity": "sha512-btzExgV+/lMGDDa194CcUQm53ncxzeBrWJcncOBxuC6ndBkKxnHdFJn86mCIgTELsooUmwUm9FkhSp5HYu00Rg==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "android"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.20.2.tgz",
+            "integrity": "sha512-4J6IRT+10J3aJH3l1yzEg9y3wkTDgDk7TSDFX+wKFiWjqWp/iCfLIYzGyasx9l0SAFPT1HwSCR+0w/h1ES/MjA==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/darwin-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.20.2.tgz",
+            "integrity": "sha512-tBcXp9KNphnNH0dfhv8KYkZhjc+H3XBkF5DKtswJblV7KlT9EI2+jeA8DgBjp908WEuYll6pF+UStUCfEpdysA==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "darwin"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.20.2.tgz",
+            "integrity": "sha512-d3qI41G4SuLiCGCFGUrKsSeTXyWG6yem1KcGZVS+3FYlYhtNoNgYrWcvkOoaqMhwXSMrZRl69ArHsGJ9mYdbbw==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/freebsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.20.2.tgz",
+            "integrity": "sha512-d+DipyvHRuqEeM5zDivKV1KuXn9WeRX6vqSqIDgwIfPQtwMP4jaDsQsDncjTDDsExT4lR/91OLjRo8bmC1e+Cw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "freebsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.20.2.tgz",
+            "integrity": "sha512-VhLPeR8HTMPccbuWWcEUD1Az68TqaTYyj6nfE4QByZIQEQVWBB8vup8PpR7y1QHL3CpcF6xd5WVBU/+SBEvGTg==",
+            "cpu": [
+                "arm"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.20.2.tgz",
+            "integrity": "sha512-9pb6rBjGvTFNira2FLIWqDk/uaf42sSyLE8j1rnUpuzsODBq7FvpwHYZxQ/It/8b+QOS1RYfqgGFNLRI+qlq2A==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.20.2.tgz",
+            "integrity": "sha512-o10utieEkNPFDZFQm9CoP7Tvb33UutoJqg3qKf1PWVeeJhJw0Q347PxMvBgVVFgouYLGIhFYG0UGdBumROyiig==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-loong64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.20.2.tgz",
+            "integrity": "sha512-PR7sp6R/UC4CFVomVINKJ80pMFlfDfMQMYynX7t1tNTeivQ6XdX5r2XovMmha/VjR1YN/HgHWsVcTRIMkymrgQ==",
+            "cpu": [
+                "loong64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-mips64el": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.20.2.tgz",
+            "integrity": "sha512-4BlTqeutE/KnOiTG5Y6Sb/Hw6hsBOZapOVF6njAESHInhlQAghVVZL1ZpIctBOoTFbQyGW+LsVYZ8lSSB3wkjA==",
+            "cpu": [
+                "mips64el"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-ppc64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.20.2.tgz",
+            "integrity": "sha512-rD3KsaDprDcfajSKdn25ooz5J5/fWBylaaXkuotBDGnMnDP1Uv5DLAN/45qfnf3JDYyJv/ytGHQaziHUdyzaAg==",
+            "cpu": [
+                "ppc64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-riscv64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.20.2.tgz",
+            "integrity": "sha512-snwmBKacKmwTMmhLlz/3aH1Q9T8v45bKYGE3j26TsaOVtjIag4wLfWSiZykXzXuE1kbCE+zJRmwp+ZbIHinnVg==",
+            "cpu": [
+                "riscv64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-s390x": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.20.2.tgz",
+            "integrity": "sha512-wcWISOobRWNm3cezm5HOZcYz1sKoHLd8VL1dl309DiixxVFoFe/o8HnwuIwn6sXre88Nwj+VwZUvJf4AFxkyrQ==",
+            "cpu": [
+                "s390x"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/linux-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.20.2.tgz",
+            "integrity": "sha512-1MdwI6OOTsfQfek8sLwgyjOXAu+wKhLEoaOLTjbijk6E2WONYpH9ZU2mNtR+lZ2B4uwr+usqGuVfFT9tMtGvGw==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "linux"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/netbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-K8/DhBxcVQkzYc43yJXDSyjlFeHQJBiowJ0uVL6Tor3jGQfSGHNNJcWxNbOI8v5k82prYqzPuwkzHt3J1T1iZQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "netbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/openbsd-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.20.2.tgz",
+            "integrity": "sha512-eMpKlV0SThJmmJgiVyN9jTPJ2VBPquf6Kt/nAoo6DgHAoN57K15ZghiHaMvqjCye/uU4X5u3YSMgVBI1h3vKrQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "openbsd"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/sunos-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.20.2.tgz",
+            "integrity": "sha512-2UyFtRC6cXLyejf/YEld4Hajo7UHILetzE1vsRcGL3earZEW77JxrFjH4Ez2qaTiEfMgAXxfAZCm1fvM/G/o8w==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "sunos"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-arm64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.20.2.tgz",
+            "integrity": "sha512-GRibxoawM9ZCnDxnP3usoUDO9vUkpAxIIZ6GQI+IlVmr5kP3zUq+l17xELTHMWTWzjxa2guPNyrpq1GWmPvcGQ==",
+            "cpu": [
+                "arm64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-ia32": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.20.2.tgz",
+            "integrity": "sha512-HfLOfn9YWmkSKRQqovpnITazdtquEW8/SoHW7pWpuEeguaZI4QnCRW6b+oZTztdBnZOS2hqJ6im/D5cPzBTTlQ==",
+            "cpu": [
+                "ia32"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/@esbuild/win32-x64": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.20.2.tgz",
+            "integrity": "sha512-N49X4lJX27+l9jbLKSqZ6bKNjzQvHaT8IIFUy+YIqmXQdjYCToGWwOItDrfby14c78aDd5NHQl29xingXfCdLQ==",
+            "cpu": [
+                "x64"
+            ],
+            "dev": true,
+            "optional": true,
+            "os": [
+                "win32"
+            ],
+            "engines": {
+                "node": ">=12"
             }
         },
         "node_modules/@eslint-community/eslint-utils": {
@@ -3169,6 +3538,44 @@
                 "node": ">= 0.4"
             }
         },
+        "node_modules/esbuild": {
+            "version": "0.20.2",
+            "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.20.2.tgz",
+            "integrity": "sha512-WdOOppmUNU+IbZ0PaDiTst80zjnrOkyJNHoKupIcVyU8Lvla3Ugx94VzkQ32Ijqd7UhHJy75gNWDMUekcrSJ6g==",
+            "dev": true,
+            "hasInstallScript": true,
+            "bin": {
+                "esbuild": "bin/esbuild"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "optionalDependencies": {
+                "@esbuild/aix-ppc64": "0.20.2",
+                "@esbuild/android-arm": "0.20.2",
+                "@esbuild/android-arm64": "0.20.2",
+                "@esbuild/android-x64": "0.20.2",
+                "@esbuild/darwin-arm64": "0.20.2",
+                "@esbuild/darwin-x64": "0.20.2",
+                "@esbuild/freebsd-arm64": "0.20.2",
+                "@esbuild/freebsd-x64": "0.20.2",
+                "@esbuild/linux-arm": "0.20.2",
+                "@esbuild/linux-arm64": "0.20.2",
+                "@esbuild/linux-ia32": "0.20.2",
+                "@esbuild/linux-loong64": "0.20.2",
+                "@esbuild/linux-mips64el": "0.20.2",
+                "@esbuild/linux-ppc64": "0.20.2",
+                "@esbuild/linux-riscv64": "0.20.2",
+                "@esbuild/linux-s390x": "0.20.2",
+                "@esbuild/linux-x64": "0.20.2",
+                "@esbuild/netbsd-x64": "0.20.2",
+                "@esbuild/openbsd-x64": "0.20.2",
+                "@esbuild/sunos-x64": "0.20.2",
+                "@esbuild/win32-arm64": "0.20.2",
+                "@esbuild/win32-ia32": "0.20.2",
+                "@esbuild/win32-x64": "0.20.2"
+            }
+        },
         "node_modules/escalade": {
             "version": "3.1.2",
             "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
@@ -3805,6 +4212,18 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
+            }
+        },
+        "node_modules/get-tsconfig": {
+            "version": "4.7.5",
+            "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.7.5.tgz",
+            "integrity": "sha512-ZCuZCnlqNzjb4QprAzXKdpp/gh6KTxSJuw3IBsPnV/7fV4NxC9ckB+vPTt8w7fJA0TaSD7c55BR47JD6MEDyDw==",
+            "dev": true,
+            "dependencies": {
+                "resolve-pkg-maps": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
             }
         },
         "node_modules/glob": {
@@ -5211,6 +5630,15 @@
                 "node": ">=4"
             }
         },
+        "node_modules/resolve-pkg-maps": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+            "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+            "dev": true,
+            "funding": {
+                "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
         "node_modules/reusify": {
             "version": "1.0.4",
             "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -5770,6 +6198,25 @@
             "version": "2.6.2",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
             "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
+        },
+        "node_modules/tsx": {
+            "version": "4.10.0",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.10.0.tgz",
+            "integrity": "sha512-Ct/j4Yv49EFlr1z5CT++ld+BUhjLRLtimE4hIDaW9zEVIp3xJOQdTDAan+KEXeme7GcYIGzFD421Zcqf9dHomw==",
+            "dev": true,
+            "dependencies": {
+                "esbuild": "~0.20.2",
+                "get-tsconfig": "^4.7.3"
+            },
+            "bin": {
+                "tsx": "dist/cli.mjs"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            },
+            "optionalDependencies": {
+                "fsevents": "~2.3.3"
+            }
         },
         "node_modules/type-check": {
             "version": "0.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,7 +42,7 @@
                 "@typescript-eslint/eslint-plugin": "^7.8.0",
                 "@typescript-eslint/parser": "^7.8.0",
                 "aws-sdk-client-mock-jest": "^4.0.0",
-                "chai": "^4.3.10",
+                "chai": "^5.1.1",
                 "eslint": "^8.54.0",
                 "eslint-config-prettier": "^9.0.0",
                 "mocha": "^10.2.0",
@@ -2510,12 +2510,12 @@
             "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA=="
         },
         "node_modules/assertion-error": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
-            "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+            "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
             "dev": true,
             "engines": {
-                "node": "*"
+                "node": ">=12"
             }
         },
         "node_modules/async": {
@@ -2736,21 +2736,19 @@
             }
         },
         "node_modules/chai": {
-            "version": "4.4.1",
-            "resolved": "https://registry.npmjs.org/chai/-/chai-4.4.1.tgz",
-            "integrity": "sha512-13sOfMv2+DWduEU+/xbun3LScLoqN17nBeTLUsmDfKdoiC1fr0n9PU4guu4AhRcOVFk/sW8LyZWHuhWtQZiF+g==",
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/chai/-/chai-5.1.1.tgz",
+            "integrity": "sha512-pT1ZgP8rPNqUgieVaEY+ryQr6Q4HXNg8Ei9UnLUrjN4IA7dvQC5JB+/kxVcPNDHyBcc/26CXPkbNzq3qwrOEKA==",
             "dev": true,
             "dependencies": {
-                "assertion-error": "^1.1.0",
-                "check-error": "^1.0.3",
-                "deep-eql": "^4.1.3",
-                "get-func-name": "^2.0.2",
-                "loupe": "^2.3.6",
-                "pathval": "^1.1.1",
-                "type-detect": "^4.0.8"
+                "assertion-error": "^2.0.1",
+                "check-error": "^2.1.1",
+                "deep-eql": "^5.0.1",
+                "loupe": "^3.1.0",
+                "pathval": "^2.0.0"
             },
             "engines": {
-                "node": ">=4"
+                "node": ">=12"
             }
         },
         "node_modules/chalk": {
@@ -2770,15 +2768,12 @@
             }
         },
         "node_modules/check-error": {
-            "version": "1.0.3",
-            "resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.3.tgz",
-            "integrity": "sha512-iKEoDYaRmd1mxM90a2OEfWhjsjPpYPuQ+lMYsoxB126+t8fw7ySEO48nmDg5COTjxDI65/Y2OWpeEHk3ZOe8zg==",
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
+            "integrity": "sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==",
             "dev": true,
-            "dependencies": {
-                "get-func-name": "^2.0.2"
-            },
             "engines": {
-                "node": "*"
+                "node": ">= 16"
             }
         },
         "node_modules/chokidar": {
@@ -3011,13 +3006,10 @@
             "integrity": "sha512-VBBaLc1MgL5XpzgIP7ny5Z6Nx3UrRkIViUkPUdtl9aya5amy3De1gsUUSB1g3+3sExYNjCAsAznmukyxCb1GRA=="
         },
         "node_modules/deep-eql": {
-            "version": "4.1.3",
-            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-4.1.3.tgz",
-            "integrity": "sha512-WaEtAOpRA1MQ0eohqZjpGD8zdI0Ovsm8mmFhaDN8dvDZzyoUMcYDnf5Y6iu7HTXxf8JDS23qWa4a+hKCDyOPzw==",
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.1.tgz",
+            "integrity": "sha512-nwQCf6ne2gez3o1MxWifqkciwt0zhl0LO1/UwVu4uMBuPmflWM4oQ70XMqHqnBJA+nhzncaqL9HVL6KkHJ28lw==",
             "dev": true,
-            "dependencies": {
-                "type-detect": "^4.0.0"
-            },
             "engines": {
                 "node": ">=6"
             }
@@ -4440,9 +4432,9 @@
             "integrity": "sha512-lcHwpNoggQTObv5apGNCTdJrO69eHOZMi4BNC+rTLER8iHAqGrUVeLh/irVIM7zTw2bOXA8T6uNPeujwOLg/2Q=="
         },
         "node_modules/loupe": {
-            "version": "2.3.7",
-            "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.7.tgz",
-            "integrity": "sha512-zSMINGVYkdpYSOBmLi0D1Uo7JU9nVdQKrHxC8eYlV+9YKK9WePqAlL7lSlorG/U2Fw1w0hTBmaa/jrQ3UbPHtA==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.1.0.tgz",
+            "integrity": "sha512-qKl+FrLXUhFuHUoDJG7f8P8gEMHq9NFS0c6ghXG1J0rldmZFQZoNVv/vyirE9qwCIhWZDsvEFd1sbFu3GvRQFg==",
             "dev": true,
             "dependencies": {
                 "get-func-name": "^2.0.1"
@@ -4988,12 +4980,12 @@
             }
         },
         "node_modules/pathval": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
-            "integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.0.tgz",
+            "integrity": "sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==",
             "dev": true,
             "engines": {
-                "node": "*"
+                "node": ">= 14.16"
             }
         },
         "node_modules/picocolors": {

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
         "prettier": "^3.1.0",
         "sinon": "^17.0.2",
         "supertest": "^7.0.0",
+        "tsx": "^4.10.0",
         "typescript": "^5.2.2"
     },
     "repository": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
         "@typescript-eslint/eslint-plugin": "^7.8.0",
         "@typescript-eslint/parser": "^7.8.0",
         "aws-sdk-client-mock-jest": "^4.0.0",
-        "chai": "^4.3.10",
+        "chai": "^5.1.1",
         "eslint": "^8.54.0",
         "eslint-config-prettier": "^9.0.0",
         "mocha": "^10.2.0",

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
     "engines": {
         "node": "18.x"
     },
+    "type": "module",
     "main": "index.ts",
     "scripts": {
         "setup-githooks": "./githooks/setup.sh",

--- a/src/PeriodicTasks/index.ts
+++ b/src/PeriodicTasks/index.ts
@@ -1,5 +1,5 @@
-import { slog } from '../services/logging';
-import { watchKimsufi } from './kimsufiWatcher';
+import { slog } from '../services/logging/index.js';
+import { watchKimsufi } from './kimsufiWatcher.js';
 
 const minutes15 = 1000 * 60 * 15;
 const hours1 = 1000 * 3600;

--- a/src/PeriodicTasks/kimsufiWatcher.ts
+++ b/src/PeriodicTasks/kimsufiWatcher.ts
@@ -1,5 +1,5 @@
 import jsdom from 'jsdom';
-import { slog } from '../services/logging';
+import { slog } from '../services/logging/index.js';
 const { JSDOM } = jsdom;
 
 export const watchKimsufi = async () => {

--- a/src/app.ts
+++ b/src/app.ts
@@ -1,15 +1,15 @@
 import express from 'express';
 import cors from 'cors';
 import { Validator } from 'express-json-validator-middleware';
-import { routes } from './routes';
-import { checkRequiredPermissions, validateAccessToken } from './middleware/auth0.middleware';
-import { errorHandler } from './middleware/errors.middleware';
+import { routes } from './routes/index.js';
+import { checkRequiredPermissions, validateAccessToken } from './middleware/auth0.middleware.js';
+import { errorHandler } from './middleware/errors.middleware.js';
 import mustacheExpress from 'mustache-express';
-import { multipartHandler } from './middleware/multipart.middleware';
-import { goatCounterHandler } from './middleware/goatcounter.middleware';
-import { loggingHandler } from './middleware/logging.middleware';
-import { startPeriodicTasks } from './PeriodicTasks';
-import { slog } from './services/logging';
+import { multipartHandler } from './middleware/multipart.middleware.js';
+import { goatCounterHandler } from './middleware/goatcounter.middleware.js';
+import { loggingHandler } from './middleware/logging.middleware.js';
+import { startPeriodicTasks } from './PeriodicTasks/index.js';
+import { slog } from './services/logging/index.js';
 
 const { validate } = new Validator({ allowUnionTypes: true });
 export let app: express.Express;

--- a/src/middleware/auth0.middleware.ts
+++ b/src/middleware/auth0.middleware.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, Response } from 'express';
 import { auth, claimCheck, InsufficientScopeError } from 'express-oauth2-jwt-bearer';
-import { isProd } from '../services/env-helpers/env';
-import { slog } from '../services/logging';
+import { isProd } from '../services/env-helpers/env.js';
+import { slog } from '../services/logging/index.js';
 
 const localAuth0 = {
     auth0Audience: 'http://localhost:3000',

--- a/src/middleware/errors.middleware.ts
+++ b/src/middleware/errors.middleware.ts
@@ -5,7 +5,7 @@ import {
     UnauthorizedError,
     InsufficientScopeError
 } from 'express-oauth2-jwt-bearer';
-import { slog } from '../services/logging';
+import { slog } from '../services/logging/index.js';
 
 export const errorHandler = async (
     error: Error,

--- a/src/middleware/goatcounter.middleware.ts
+++ b/src/middleware/goatcounter.middleware.ts
@@ -1,5 +1,5 @@
 import { NextFunction, Request, Response } from 'express';
-import { isProd } from '../services/env-helpers/env';
+import { isProd } from '../services/env-helpers/env.js';
 
 // Token is from https://api-statox-fr.goatcounter.com/user/api
 const token = isProd ? process.env.GOATCOUNTER_TOKEN : '';

--- a/src/middleware/logging.middleware.ts
+++ b/src/middleware/logging.middleware.ts
@@ -1,8 +1,8 @@
 import { NextFunction, Request, Response } from 'express';
 import { randomUUID } from 'crypto';
 import { hrtime } from 'node:process';
-import { slog } from '../services/logging';
-import { isTests } from '../services/env-helpers/env';
+import { slog } from '../services/logging/index.js';
+import { isTests } from '../services/env-helpers/env.js';
 
 export const loggingHandler = async (req: Request, res: Response, next: NextFunction) => {
     const path = req.path;

--- a/src/routes/chords/addLinkVisit.ts
+++ b/src/routes/chords/addLinkVisit.ts
@@ -1,8 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 import { AllowedSchema } from 'express-json-validator-middleware';
-import { PostRoute } from '../types';
-import { addLinkVisit } from '../../services/chords';
-import { slog } from '../../services/logging';
+import { PostRoute } from '../types.js';
+import { addLinkVisit } from '../../services/chords/index.js';
+import { slog } from '../../services/logging/index.js';
 
 const handler = async (req: Request, res: Response, next: NextFunction) => {
     const { url } = req.body;

--- a/src/routes/chords/checkLinks.ts
+++ b/src/routes/chords/checkLinks.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express';
-import { checkChordsUrl } from '../../services/chords';
-import { GetRoute } from '../types';
+import { checkChordsUrl } from '../../services/chords/index.js';
+import { GetRoute } from '../types.js';
 
 const handler = async (_req: Request, res: Response) => {
     const checkResults = await checkChordsUrl();

--- a/src/routes/chords/getAll.ts
+++ b/src/routes/chords/getAll.ts
@@ -1,6 +1,6 @@
 import type { Request, Response } from 'express';
-import { getAllChords } from '../../services/chords';
-import { GetRoute } from '../types';
+import { getAllChords } from '../../services/chords/index.js';
+import { GetRoute } from '../types.js';
 
 const handler = async (_req: Request, res: Response) => {
     const chords = await getAllChords();

--- a/src/routes/chords/getLinksVisitsCount.ts
+++ b/src/routes/chords/getLinksVisitsCount.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import { GetRoute } from '../types';
-import { getLinksVisitsCount } from '../../services/chords';
+import { GetRoute } from '../types.js';
+import { getLinksVisitsCount } from '../../services/chords/index.js';
 
 const handler = async (_req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/routes/chords/updateAll.ts
+++ b/src/routes/chords/updateAll.ts
@@ -1,8 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 import { AllowedSchema } from 'express-json-validator-middleware';
-import { PostRoute } from '../types';
-import { updateChords } from '../../services/chords/commands';
-import { slog } from '../../services/logging';
+import { PostRoute } from '../types.js';
+import { updateChords } from '../../services/chords/commands.js';
+import { slog } from '../../services/logging/index.js';
 
 const handler = async (req: Request, res: Response, next: NextFunction) => {
     const { chords } = req.body;

--- a/src/routes/clipboard/addEntry.ts
+++ b/src/routes/clipboard/addEntry.ts
@@ -1,8 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 import { File } from 'formidable';
 import { AllowedSchema } from 'express-json-validator-middleware';
-import { PostRoute } from '../types';
-import { addEntry } from '../../services/clipboard';
+import { PostRoute } from '../types.js';
+import { addEntry } from '../../services/clipboard/index.js';
 
 import type { QueryError } from 'mysql2';
 

--- a/src/routes/clipboard/deleteEntry.ts
+++ b/src/routes/clipboard/deleteEntry.ts
@@ -1,7 +1,7 @@
 import type { NextFunction, Request, Response } from 'express';
 import { AllowedSchema } from 'express-json-validator-middleware';
-import { PostRoute } from '../types';
-import { deleteEntry } from '../../services/clipboard';
+import { PostRoute } from '../types.js';
+import { deleteEntry } from '../../services/clipboard/index.js';
 
 const handler = async (req: Request, res: Response, next: NextFunction) => {
     const { name } = req.body;

--- a/src/routes/clipboard/getAllEntries.ts
+++ b/src/routes/clipboard/getAllEntries.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import { GetRoute } from '../types';
-import { getAllEntries } from '../../services/clipboard';
+import { GetRoute } from '../types.js';
+import { getAllEntries } from '../../services/clipboard/index.js';
 
 const handler = async (_req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/routes/clipboard/getPublicEntries.ts
+++ b/src/routes/clipboard/getPublicEntries.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import { GetRoute } from '../types';
-import { getPublicEntries } from '../../services/clipboard';
+import { GetRoute } from '../types.js';
+import { getPublicEntries } from '../../services/clipboard/index.js';
 
 const handler = async (_req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/routes/clipboard/staticView.ts
+++ b/src/routes/clipboard/staticView.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import { GetRoute } from '../types';
-import { getEntriesForStaticView } from '../../services/clipboard';
+import { GetRoute } from '../types.js';
+import { getEntriesForStaticView } from '../../services/clipboard/index.js';
 
 const handler = async (_req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/routes/health/getRemoteTime.ts
+++ b/src/routes/health/getRemoteTime.ts
@@ -1,5 +1,5 @@
 import type { Request, Response } from 'express';
-import { GetRoute } from '../types';
+import { GetRoute } from '../types.js';
 
 const handler = (_req: Request, res: Response) => {
     const o = { time: Date.now() };

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,18 +1,18 @@
-import { Route } from './types';
-import { route as addLinkVisit } from './chords/addLinkVisit';
-import { route as getAllChords } from './chords/getAll';
-import { route as getLinksVisitsCount } from './chords/getLinksVisitsCount';
-import { route as updateAllChords } from './chords/updateAll';
-import { route as checkLinks } from './chords/checkLinks';
-import { route as addEntry } from './clipboard/addEntry';
-import { route as deleteClipboardEntry } from './clipboard/deleteEntry';
-import { route as getClipboardPublicEntries } from './clipboard/getPublicEntries';
-import { route as getClipboardAllEntries } from './clipboard/getAllEntries';
-import { route as clipboardStaticView } from './clipboard/staticView';
-import { route as getRemoteTime } from './health/getRemoteTime';
-import { route as reactorAddEntry } from './reactor/addEntry';
-import { route as reactorGetEntry } from './reactor/getEntry';
-import { route as reactorGetForPublic } from './reactor/getEntriesForPublic';
+import { Route } from './types.js';
+import { route as addLinkVisit } from './chords/addLinkVisit.js';
+import { route as getAllChords } from './chords/getAll.js';
+import { route as getLinksVisitsCount } from './chords/getLinksVisitsCount.js';
+import { route as updateAllChords } from './chords/updateAll.js';
+import { route as checkLinks } from './chords/checkLinks.js';
+import { route as addEntry } from './clipboard/addEntry.js';
+import { route as deleteClipboardEntry } from './clipboard/deleteEntry.js';
+import { route as getClipboardPublicEntries } from './clipboard/getPublicEntries.js';
+import { route as getClipboardAllEntries } from './clipboard/getAllEntries.js';
+import { route as clipboardStaticView } from './clipboard/staticView.js';
+import { route as getRemoteTime } from './health/getRemoteTime.js';
+import { route as reactorAddEntry } from './reactor/addEntry.js';
+import { route as reactorGetEntry } from './reactor/getEntry.js';
+import { route as reactorGetForPublic } from './reactor/getEntriesForPublic.js';
 
 export const routes: Route[] = [
     addEntry,

--- a/src/routes/reactor/addEntry.ts
+++ b/src/routes/reactor/addEntry.ts
@@ -1,8 +1,8 @@
 import type { NextFunction, Request, Response } from 'express';
 import { File } from 'formidable';
 import { AllowedSchema } from 'express-json-validator-middleware';
-import { PostRoute } from '../types';
-import { addEntry } from '../../services/reactor';
+import { PostRoute } from '../types.js';
+import { addEntry } from '../../services/reactor/index.js';
 
 import type { QueryError } from 'mysql2';
 

--- a/src/routes/reactor/getEntriesForPublic.ts
+++ b/src/routes/reactor/getEntriesForPublic.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import { GetRoute } from '../types';
-import { getEntriesForPublic } from '../../services/reactor';
+import { GetRoute } from '../types.js';
+import { getEntriesForPublic } from '../../services/reactor/index.js';
 
 const handler = async (_req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/routes/reactor/getEntry.ts
+++ b/src/routes/reactor/getEntry.ts
@@ -1,6 +1,6 @@
 import type { NextFunction, Request, Response } from 'express';
-import { GetRoute } from '../types';
-import { getEntryPresignedUrl } from '../../services/reactor';
+import { GetRoute } from '../types.js';
+import { getEntryPresignedUrl } from '../../services/reactor/index.js';
 
 const handler = async (req: Request, res: Response, next: NextFunction) => {
     try {

--- a/src/services/chords/commands.ts
+++ b/src/services/chords/commands.ts
@@ -1,7 +1,7 @@
 import { PutObjectCommand, PutObjectCommandInput } from '@aws-sdk/client-s3';
-import { Chord } from './types';
-import { S3 } from '../env-helpers/s3';
-import { slog } from '../logging';
+import { Chord } from './types.js';
+import { S3 } from '../env-helpers/s3.js';
+import { slog } from '../logging/index.js';
 
 export const updateChords = async (chords: Chord[]) => {
     try {

--- a/src/services/chords/index.ts
+++ b/src/services/chords/index.ts
@@ -1,4 +1,4 @@
-import { checkChordsUrl } from './urlsChecker';
-import { addLinkVisit, getAllChords, getLinksVisitsCount } from './queries';
+import { checkChordsUrl } from './urlsChecker.js';
+import { addLinkVisit, getAllChords, getLinksVisitsCount } from './queries.js';
 
 export { addLinkVisit, checkChordsUrl, getAllChords, getLinksVisitsCount };

--- a/src/services/chords/queries.ts
+++ b/src/services/chords/queries.ts
@@ -1,9 +1,9 @@
 import { GetObjectCommand } from '@aws-sdk/client-s3';
 import { RowDataPacket } from 'mysql2';
-import { Chord } from './types';
-import { db } from '../env-helpers/db';
-import { S3 } from '../env-helpers/s3';
-import { slog } from '../logging';
+import { Chord } from './types.js';
+import { db } from '../env-helpers/db.js';
+import { S3 } from '../env-helpers/s3.js';
+import { slog } from '../logging/index.js';
 
 export const addLinkVisit = async (params: { url: string }) => {
     return db.query(

--- a/src/services/chords/urlsChecker.ts
+++ b/src/services/chords/urlsChecker.ts
@@ -1,6 +1,6 @@
 import fs from 'node:fs';
-import { Chord } from './types';
-import { getAllChords } from './queries';
+import { Chord } from './types.js';
+import { getAllChords } from './queries.js';
 
 const RESULTS_FILE_PATH = './chords_check_results.json';
 const RESULTS_FILE_TTL = 1000 * 60 * 15; // 15 minutes

--- a/src/services/clipboard/addEntry.ts
+++ b/src/services/clipboard/addEntry.ts
@@ -2,9 +2,9 @@ import { File } from 'formidable';
 import { PutObjectCommand, PutObjectCommandInput } from '@aws-sdk/client-s3';
 import mime from 'mime-types';
 import * as fs from 'fs';
-import { generate4BytesHex } from '../random';
-import { S3 } from '../env-helpers/s3';
-import { db } from '../env-helpers/db';
+import { generate4BytesHex } from '../random.js';
+import { S3 } from '../env-helpers/s3.js';
+import { db } from '../env-helpers/db.js';
 
 type NewEntryParams = {
     name: string;

--- a/src/services/clipboard/deleteEntry.ts
+++ b/src/services/clipboard/deleteEntry.ts
@@ -1,7 +1,7 @@
 import { RowDataPacket } from 'mysql2';
 import { DeleteObjectCommand, DeleteObjectCommandInput } from '@aws-sdk/client-s3';
-import { db } from '../env-helpers/db';
-import { S3 } from '../env-helpers/s3';
+import { db } from '../env-helpers/db.js';
+import { S3 } from '../env-helpers/s3.js';
 
 export const deleteEntry = async (params: { name: string }) => {
     const [rows] = await db.query<RowDataPacket[]>('SELECT s3Key FROM Clipboard WHERE name = ?', [

--- a/src/services/clipboard/getEntries.ts
+++ b/src/services/clipboard/getEntries.ts
@@ -1,5 +1,5 @@
-import { db } from '../env-helpers/db';
-import { getPresignedUrl } from '../env-helpers/s3';
+import { db } from '../env-helpers/db.js';
+import { getPresignedUrl } from '../env-helpers/s3.js';
 
 type ClipboardEntry = {
     id: number;

--- a/src/services/clipboard/index.ts
+++ b/src/services/clipboard/index.ts
@@ -1,5 +1,5 @@
-import { addEntry } from './addEntry';
-import { deleteEntry } from './deleteEntry';
-import { getAllEntries, getEntriesForStaticView, getPublicEntries } from './getEntries';
+import { addEntry } from './addEntry.js';
+import { deleteEntry } from './deleteEntry.js';
+import { getAllEntries, getEntriesForStaticView, getPublicEntries } from './getEntries.js';
 
 export { addEntry, deleteEntry, getAllEntries, getEntriesForStaticView, getPublicEntries };

--- a/src/services/env-helpers/db.ts
+++ b/src/services/env-helpers/db.ts
@@ -1,7 +1,7 @@
 import mysql, { Pool, PoolOptions } from 'mysql2/promise';
 import url from 'url';
-import { isProd, isTests } from './env';
-import { slog } from '../logging';
+import { isProd, isTests } from './env.js';
+import { slog } from '../logging/index.js';
 
 const PROD_URL = process.env.JAWSDB_URL;
 const DEV_URL = 'mysql://root:example@127.0.0.1:13306/db';

--- a/src/services/env-helpers/elk.ts
+++ b/src/services/env-helpers/elk.ts
@@ -1,4 +1,4 @@
-import { isProd } from './env';
+import { isProd } from './env.js';
 
 export const ELK_DOMAIN_ENDPOINT = isProd ? process.env.ELK_DOMAIN_ENDPOINT : 'https://127.0.0.1';
 const LOGGER_USER = isProd ? process.env.LOGGER_USER : 'test';

--- a/src/services/env-helpers/s3.ts
+++ b/src/services/env-helpers/s3.ts
@@ -6,7 +6,7 @@ import {
     S3Client
 } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
-import { isProd, isTests } from './env';
+import { isProd, isTests } from './env.js';
 import { AwsClientStub, mockClient } from 'aws-sdk-client-mock';
 import { sdkStreamMixin } from '@smithy/util-stream';
 import { Readable } from 'stream';

--- a/src/services/logging/elk.ts
+++ b/src/services/logging/elk.ts
@@ -5,8 +5,8 @@ import {
     ELK_TOKEN_2,
     ELK_DOMAIN_ENDPOINT,
     ELK_TOKEN
-} from '../env-helpers/elk';
-import { LogObject } from './slog';
+} from '../env-helpers/elk.js';
+import { LogObject } from './slog.js';
 
 // WARNING This disable SSL certificate checks for all queries but I need it only for
 // my self hosted stack

--- a/src/services/logging/index.ts
+++ b/src/services/logging/index.ts
@@ -1,1 +1,1 @@
-export * as slog from './slog';
+export * as slog from './slog.js';

--- a/src/services/logging/slack.ts
+++ b/src/services/logging/slack.ts
@@ -1,5 +1,5 @@
 import { IncomingWebhook } from '@slack/webhook';
-import { isProd } from '../env-helpers/env';
+import { isProd } from '../env-helpers/env.js';
 
 const url = isProd ? process.env.LOGS_SLACK_WEBHOOK_URL : '';
 

--- a/src/services/logging/slog.ts
+++ b/src/services/logging/slog.ts
@@ -1,6 +1,6 @@
-import { isDebug, isProd, isTests } from '../env-helpers/env';
-import { logToELK } from './elk';
-import { logErrorToSlack, logMessageToSlack } from './slack';
+import { isDebug, isProd, isTests } from '../env-helpers/env.js';
+import { logToELK } from './elk.js';
+import { logErrorToSlack, logMessageToSlack } from './slack.js';
 
 type CloudflareGeoInfo = {
     'cf-ipcity'?: string;

--- a/src/services/reactor/addEntry.ts
+++ b/src/services/reactor/addEntry.ts
@@ -2,9 +2,9 @@ import { File } from 'formidable';
 import { PutObjectCommand, PutObjectCommandInput } from '@aws-sdk/client-s3';
 import mime from 'mime-types';
 import * as fs from 'fs';
-import { generate4BytesHex } from '../random';
-import { S3 } from '../env-helpers/s3';
-import { db } from '../env-helpers/db';
+import { generate4BytesHex } from '../random.js';
+import { S3 } from '../env-helpers/s3.js';
+import { db } from '../env-helpers/db.js';
 
 type NewEntryParams = {
     name: string;

--- a/src/services/reactor/getEntries.ts
+++ b/src/services/reactor/getEntries.ts
@@ -1,7 +1,7 @@
 import { RowDataPacket } from 'mysql2/promise';
-import { db } from '../env-helpers/db';
-import { getPresignedUrl } from '../env-helpers/s3';
-import { slog } from '../logging';
+import { db } from '../env-helpers/db.js';
+import { getPresignedUrl } from '../env-helpers/s3.js';
+import { slog } from '../logging/index.js';
 
 interface DBReactorEntryForPublic extends RowDataPacket {
     name: string;

--- a/src/services/reactor/index.ts
+++ b/src/services/reactor/index.ts
@@ -1,4 +1,4 @@
-import { addEntry } from './addEntry';
-import { getEntriesForPublic, getEntryPresignedUrl } from './getEntries';
+import { addEntry } from './addEntry.js';
+import { getEntriesForPublic, getEntryPresignedUrl } from './getEntries.js';
 
 export { addEntry, getEntriesForPublic, getEntryPresignedUrl };

--- a/tests/framework/logging.test.ts
+++ b/tests/framework/logging.test.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import request from 'supertest';
-import { app } from '../../src/app';
-import { slogCheckLog } from '../helpers/slog';
+import { app } from '../../src/app.js';
+import { slogCheckLog } from '../helpers/slog/index.js';
 
 describe('logging middleware', () => {
     it('should emit an access-log when the request finishes', async () => {

--- a/tests/framework/routes.test.ts
+++ b/tests/framework/routes.test.ts
@@ -1,8 +1,11 @@
 import sinon from 'sinon';
 import request from 'supertest';
-import { app } from '../../src/app';
-import { fakeCheckRequiredPermissionsHandler, fakeValidateAccessToken } from '../helpers/auth';
-import { slogCheckLog } from '../helpers/slog';
+import { app } from '../../src/app.js';
+import {
+    fakeCheckRequiredPermissionsHandler,
+    fakeValidateAccessToken
+} from '../helpers/auth/index.js';
+import { slogCheckLog } from '../helpers/slog/index.js';
 import { ValidationError } from 'express-json-validator-middleware';
 import { assert } from 'chai';
 

--- a/tests/helpers/app/index.ts
+++ b/tests/helpers/app/index.ts
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 import { Request, Response } from 'express';
-import * as routes from '../../../src/routes';
-import { GetRoute, PostRoute } from '../../../src/routes/types';
-import { initApp } from '../../../src/app';
+import * as routes from '../../../src/routes/index.js';
+import { GetRoute, PostRoute } from '../../../src/routes/types.js';
+import { initApp } from '../../../src/app.js';
 
 const getRoute: GetRoute = {
     method: 'get',

--- a/tests/helpers/auth/index.ts
+++ b/tests/helpers/auth/index.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import { NextFunction, Request, Response } from 'express';
-import * as auth from '../../../src/middleware/auth0.middleware';
+import * as auth from '../../../src/middleware/auth0.middleware.js';
 
 // exported for framework tests
 export let fakeValidateAccessToken: sinon.SinonStub;

--- a/tests/helpers/mocha/frameworkMochaWrapper.ts
+++ b/tests/helpers/mocha/frameworkMochaWrapper.ts
@@ -1,9 +1,9 @@
-import { initDb } from '../../../src/services/env-helpers/db';
-import { restoreAppStub, setupAppStub } from '../app';
-import { restoreFakeAuth, setupFakeAuth } from '../auth';
-import { mysqlClearAllTables } from '../mysql';
-import { setupS3Spy } from '../s3';
-import { restoreSlogSpy, setupSlogSpy } from '../slog';
+import { initDb } from '../../../src/services/env-helpers/db.js';
+import { restoreAppStub, setupAppStub } from '../app/index.js';
+import { restoreFakeAuth, setupFakeAuth } from '../auth/index.js';
+import { mysqlClearAllTables } from '../mysql/index.js';
+import { setupS3Spy } from '../s3/index.js';
+import { restoreSlogSpy, setupSlogSpy } from '../slog/index.js';
 
 // Used for test of the framework (don't init the app as some mocking is done directly in the test suite)
 export const mochaHooks = () => {

--- a/tests/helpers/mocha/routesMochaWrapper.ts
+++ b/tests/helpers/mocha/routesMochaWrapper.ts
@@ -1,9 +1,9 @@
-import { initApp } from '../../../src/app';
-import { initDb } from '../../../src/services/env-helpers/db';
-import { restoreFakeAuth, setupFakeAuth } from '../auth';
-import { mysqlClearAllTables } from '../mysql';
-import { setupS3Spy } from '../s3';
-import { restoreSlogSpy, setupSlogSpy } from '../slog';
+import { initApp } from '../../../src/app.js';
+import { initDb } from '../../../src/services/env-helpers/db.js';
+import { restoreFakeAuth, setupFakeAuth } from '../auth/index.js';
+import { mysqlClearAllTables } from '../mysql/index.js';
+import { setupS3Spy } from '../s3/index.js';
+import { restoreSlogSpy, setupSlogSpy } from '../slog/index.js';
 
 // Used for tests of the routes
 export const mochaHooks = () => {

--- a/tests/helpers/mysql/index.ts
+++ b/tests/helpers/mysql/index.ts
@@ -1,8 +1,8 @@
-import { mysqlCheckContains } from './mysqlCheckContains';
-import { mysqlCheckDoesNotContain } from './mysqlCheckDoesNotContain';
-import { mysqlClearAllTables } from './mysqlClearTables';
-import { mysqlDumpTables } from './mysqlDumpTables';
-import { mysqlFixture } from './mysqlFixture';
+import { mysqlCheckContains } from './mysqlCheckContains.js';
+import { mysqlCheckDoesNotContain } from './mysqlCheckDoesNotContain.js';
+import { mysqlClearAllTables } from './mysqlClearTables.js';
+import { mysqlDumpTables } from './mysqlDumpTables.js';
+import { mysqlFixture } from './mysqlFixture.js';
 
 export {
     mysqlCheckContains,

--- a/tests/helpers/mysql/mysqlCheckContains.ts
+++ b/tests/helpers/mysql/mysqlCheckContains.ts
@@ -1,6 +1,6 @@
 import { RowDataPacket } from 'mysql2/promise';
-import { db } from '../../../src/services/env-helpers/db';
-import { ColumnCheckFunction, MysqlCheckData, TableCheck } from './types';
+import { db } from '../../../src/services/env-helpers/db.js';
+import { ColumnCheckFunction, MysqlCheckData, TableCheck } from './types.js';
 
 const checkTableContains = async (table: string, checks: TableCheck[]) => {
     for (const row of checks) {

--- a/tests/helpers/mysql/mysqlCheckDoesNotContain.ts
+++ b/tests/helpers/mysql/mysqlCheckDoesNotContain.ts
@@ -1,6 +1,6 @@
 import { RowDataPacket } from 'mysql2';
-import { MysqlCheckData, TableCheck } from './types';
-import { db } from '../../../src/services/env-helpers/db';
+import { MysqlCheckData, TableCheck } from './types.js';
+import { db } from '../../../src/services/env-helpers/db.js';
 
 const checkTableDoesNotContain = async (table: string, checks: TableCheck[]) => {
     for (const row of checks) {

--- a/tests/helpers/mysql/mysqlClearTables.ts
+++ b/tests/helpers/mysql/mysqlClearTables.ts
@@ -1,5 +1,5 @@
 import { RowDataPacket } from 'mysql2';
-import { db } from '../../../src/services/env-helpers/db';
+import { db } from '../../../src/services/env-helpers/db.js';
 
 const listAllTables = async () => {
     const [rows] = await db.query<RowDataPacket[]>('SHOW TABLES');

--- a/tests/helpers/mysql/mysqlDumpTables.ts
+++ b/tests/helpers/mysql/mysqlDumpTables.ts
@@ -1,5 +1,5 @@
 import { RowDataPacket } from 'mysql2';
-import { db } from '../../../src/services/env-helpers/db';
+import { db } from '../../../src/services/env-helpers/db.js';
 
 export const mysqlDumpTables = async (tables: string[] | string) => {
     if (!Array.isArray(tables)) {

--- a/tests/helpers/mysql/mysqlFixture.ts
+++ b/tests/helpers/mysql/mysqlFixture.ts
@@ -1,5 +1,5 @@
 import { raw } from 'mysql2';
-import { db } from '../../../src/services/env-helpers/db';
+import { db } from '../../../src/services/env-helpers/db.js';
 
 type MysqlFixture = {
     [table: string]: { [column: string]: string | number | boolean | null }[];

--- a/tests/helpers/s3/index.ts
+++ b/tests/helpers/s3/index.ts
@@ -1,7 +1,7 @@
 import sinon from 'sinon';
 import { DeleteObjectCommand, GetObjectCommand, PutObjectCommand } from '@aws-sdk/client-s3';
 import { assert } from 'chai';
-import { s3Mock } from '../../../src/services/env-helpers/s3';
+import { s3Mock } from '../../../src/services/env-helpers/s3.js';
 import 'aws-sdk-client-mock-jest';
 
 export const setupS3Spy = () => {

--- a/tests/helpers/slog/index.ts
+++ b/tests/helpers/slog/index.ts
@@ -1,8 +1,8 @@
 import sinon from 'sinon';
 import { assert } from 'chai';
-import { slog } from '../../../src/services/logging';
-import { LogObject } from '../../../src/services/logging/slog';
-import { isDebug } from '../../../src/services/env-helpers/env';
+import { slog } from '../../../src/services/logging/index.js';
+import { LogObject } from '../../../src/services/logging/slog.js';
+import { isDebug } from '../../../src/services/env-helpers/env.js';
 
 let slogSpy: sinon.SinonSpy;
 

--- a/tests/routes/chords/addLinkVisit/addLinkVisit.test.ts
+++ b/tests/routes/chords/addLinkVisit/addLinkVisit.test.ts
@@ -1,9 +1,9 @@
 import sinon from 'sinon';
 import request from 'supertest';
-import { app } from '../../../../src/app';
-import { mysqlCheckContains, mysqlFixture } from '../../../helpers/mysql';
+import { app } from '../../../../src/app.js';
+import { mysqlCheckContains, mysqlFixture } from '../../../helpers/mysql/index.js';
 import { assert } from 'chai';
-import { slogCheckLog } from '../../../helpers/slog';
+import { slogCheckLog } from '../../../helpers/slog/index.js';
 
 describe('addLinkVisit', () => {
     it('should check input schema', async () => {

--- a/tests/routes/chords/getLinksVisitsCount/getLinksVisitsCount.test.ts
+++ b/tests/routes/chords/getLinksVisitsCount/getLinksVisitsCount.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { expect } from 'chai';
-import { app } from '../../../../src/app';
-import { mysqlFixture } from '../../../helpers/mysql';
+import { app } from '../../../../src/app.js';
+import { mysqlFixture } from '../../../helpers/mysql/index.js';
 
 describe('getLinksVisitsCount', () => {
     it('should return the visit counts ordered by descending order', async () => {

--- a/tests/routes/chords/updateAll/updateAll.test.ts
+++ b/tests/routes/chords/updateAll/updateAll.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
-import { app } from '../../../../src/app';
-import { s3CheckCall } from '../../../helpers/s3';
-import { slogCheckLog } from '../../../helpers/slog';
+import { app } from '../../../../src/app.js';
+import { s3CheckCall } from '../../../helpers/s3/index.js';
+import { slogCheckLog } from '../../../helpers/slog/index.js';
 
 describe('chords/updateAll', () => {
     it('should work', async () => {

--- a/tests/routes/clipboard/addEntry.test.ts
+++ b/tests/routes/clipboard/addEntry.test.ts
@@ -1,8 +1,8 @@
 import request from 'supertest';
 import { expect } from 'chai';
-import { app } from '../../../src/app';
-import { mysqlCheckContains, mysqlFixture } from '../../helpers/mysql';
-import { s3CheckCall } from '../../helpers/s3';
+import { app } from '../../../src/app.js';
+import { mysqlCheckContains, mysqlFixture } from '../../helpers/mysql/index.js';
+import { s3CheckCall } from '../../helpers/s3/index.js';
 
 describe('clipboard/addEntry', () => {
     it('should reject a query if no file and no content are provided', async () => {

--- a/tests/routes/clipboard/deleteEntry.test.ts
+++ b/tests/routes/clipboard/deleteEntry.test.ts
@@ -1,7 +1,11 @@
 import request from 'supertest';
-import { app } from '../../../src/app';
-import { mysqlCheckContains, mysqlCheckDoesNotContain, mysqlFixture } from '../../helpers/mysql';
-import { s3CheckCall } from '../../helpers/s3';
+import { app } from '../../../src/app.js';
+import {
+    mysqlCheckContains,
+    mysqlCheckDoesNotContain,
+    mysqlFixture
+} from '../../helpers/mysql/index.js';
+import { s3CheckCall } from '../../helpers/s3/index.js';
 
 describe('clipboard/deleteEntry', () => {
     it('should delete an existing entry', async () => {

--- a/tests/routes/clipboard/getAllEntries.test.ts
+++ b/tests/routes/clipboard/getAllEntries.test.ts
@@ -1,8 +1,8 @@
 import request from 'supertest';
 import { DateTime } from 'luxon';
 import { expect } from 'chai';
-import { mysqlFixture } from '../../helpers/mysql';
-import { app } from '../../../src/app';
+import { mysqlFixture } from '../../helpers/mysql/index.js';
+import { app } from '../../../src/app.js';
 
 describe('clipboard/getAllEntries', () => {
     it('Should retieve all entries', async () => {

--- a/tests/routes/clipboard/getPublicEntries.test.ts
+++ b/tests/routes/clipboard/getPublicEntries.test.ts
@@ -1,8 +1,8 @@
 import request from 'supertest';
 import { DateTime } from 'luxon';
 import { expect } from 'chai';
-import { mysqlFixture } from '../../helpers/mysql';
-import { app } from '../../../src/app';
+import { mysqlFixture } from '../../helpers/mysql/index.js';
+import { app } from '../../../src/app.js';
 
 describe('clipboard/getPublicEntries', () => {
     it('Should retieve only public entries', async () => {

--- a/tests/routes/clipboard/staticView.test.ts
+++ b/tests/routes/clipboard/staticView.test.ts
@@ -1,8 +1,8 @@
 import request from 'supertest';
 import { DateTime } from 'luxon';
 import { expect } from 'chai';
-import { mysqlFixture } from '../../helpers/mysql';
-import { app } from '../../../src/app';
+import { mysqlFixture } from '../../helpers/mysql/index.js';
+import { app } from '../../../src/app.js';
 
 describe('clipboard/view', () => {
     it('Should generate HTML page with only public non expired entries with an s3Key', async () => {

--- a/tests/routes/health/getRemoteTime/getRemoteTime.test.ts
+++ b/tests/routes/health/getRemoteTime/getRemoteTime.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
 import { expect } from 'chai';
-import { app } from '../../../../src/app';
+import { app } from '../../../../src/app.js';
 
 describe('getRemoteTime', () => {
     it('should return a timestamp close to now', () => {

--- a/tests/routes/reactor/addEntry.test.ts
+++ b/tests/routes/reactor/addEntry.test.ts
@@ -1,8 +1,8 @@
 import request from 'supertest';
 import { assert } from 'chai';
-import { app } from '../../../src/app';
-import { mysqlCheckContains, mysqlFixture } from '../../helpers/mysql';
-import { s3CheckCall } from '../../helpers/s3';
+import { app } from '../../../src/app.js';
+import { mysqlCheckContains, mysqlFixture } from '../../helpers/mysql/index.js';
+import { s3CheckCall } from '../../helpers/s3/index.js';
 
 describe('reactor/addEntry', () => {
     it('should fail on duplicate entry', async () => {

--- a/tests/routes/reactor/getEntriesForPublic.test.ts
+++ b/tests/routes/reactor/getEntriesForPublic.test.ts
@@ -1,7 +1,7 @@
 import request from 'supertest';
 import { assert } from 'chai';
-import { mysqlFixture } from '../../helpers/mysql';
-import { app } from '../../../src/app';
+import { mysqlFixture } from '../../helpers/mysql/index.js';
+import { app } from '../../../src/app.js';
 
 describe('reactor/getEntriesForPublic', () => {
     it('Should retrieve all entries and format the tags and s3key properly', async () => {

--- a/tests/routes/reactor/getEntry.test.ts
+++ b/tests/routes/reactor/getEntry.test.ts
@@ -1,6 +1,6 @@
 import request from 'supertest';
-import { mysqlFixture } from '../../helpers/mysql';
-import { app } from '../../../src/app';
+import { mysqlFixture } from '../../helpers/mysql/index.js';
+import { app } from '../../../src/app.js';
 import { assert } from 'chai';
 
 describe('r/:linkId', () => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,12 +1,13 @@
 {
     "compilerOptions": {
+        "module": "nodenext",
+        "moduleResolution": "nodenext",
         "lib": ["es2021"],
         "allowJs": true,
         "checkJs": true,
         "esModuleInterop": true,
         "forceConsistentCasingInFileNames": true,
         "outDir": "dist",
-        "resolveJsonModule": true,
         "skipLibCheck": true,
         "sourceMap": true,
         "strict": true


### PR DESCRIPTION
Checking how painful it would be to switch to ESM.

## Done

- Changed `package.json` and `tsconfig.json` so that the transpiled JS code uses `import/export` instead of `require`
- Changed the imports because ESM require full import path. *Note* we are using `index.js` (*.js*) files and it seems to be fine the dev.to blogpost says the same thing and explains why
- Update Mocha to start directly the typescript tests and not the transpiled JS ones. *Note* I tried using `ts-node` as the loader but it doesn't work as nice as the `tsx` loader. I think `tsx` is the right way to go.

## Todo

- Fix the modules for stubbing: With ESM it's not possible to stub the exports of high level so the stubbed modules need to export their functions in an objects instead of exporting them directly.
- Fix the async startup: From what I understand ESM exports are immutable so when importing e.g. `app` from `src/app.ts` in the tests we get an `undefined` variable because `initApp()` hasn't run yet (same for the `db` object) so the tests don't run properly. I probably need to leverage the top level async feature of ESM to fix that.

## Resources

- https://dev.to/logto/migrate-a-60k-loc-typescript-nodejs-repo-to-esm-and-testing-become-4x-faster-12-5f82
- https://github.com/logto-io/logto/pull/2491/files